### PR TITLE
Duckdb - install the httpfs extension

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,12 @@ services:
       /usr/bin/mc policy set public minio/user-payments;
       exit 0;
       "
+  duckdb:
+    build: ./duckdb
+    container_name: duckdb
+    volumes:
+      - ./duckdb:/duckdb
+
 volumes:
   postgres:
   minio:

--- a/duckdb/Dockerfile
+++ b/duckdb/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9
+
+# Update OS and install packages
+RUN apt-get update --yes && \
+    apt-get dist-upgrade --yes && \
+    apt-get install --yes \
+      wget \
+      zip
+
+ARG DUCKDB_VERSION="0.6.1"
+ARG LOCAL_BIN="/sbin"
+
+WORKDIR /
+
+# Install DuckDB CLI
+RUN wget https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-aarch64.zip --output-document=/tmp/duckdb.zip && \
+    unzip /tmp/duckdb.zip -d ${LOCAL_BIN} && \
+    rm /tmp/duckdb.zip
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/duckdb/init.sql
+++ b/duckdb/init.sql
@@ -1,3 +1,4 @@
+install 'httpfs';
 load 'httpfs';
 
 set s3_endpoint='localhost:9000';

--- a/duckdb/init.sql
+++ b/duckdb/init.sql
@@ -1,7 +1,7 @@
 install 'httpfs';
 load 'httpfs';
 
-set s3_endpoint='localhost:9000';
+set s3_endpoint='minio:9000';
 set s3_access_key_id='minio';
 set s3_secret_access_key='minio123';
 set s3_use_ssl=false;


### PR DESCRIPTION
The duckdb script will fail without first installing the httpfs extension